### PR TITLE
Moved print results

### DIFF
--- a/Get-MailboxAccessList.ps1
+++ b/Get-MailboxAccessList.ps1
@@ -48,9 +48,9 @@ function MailboxAccess {
                 $AccessList += (Get-ADGroupMember -Identity $item -Server tss.oregonstate.edu -Recursive | select name | Out-String) 
             }
         }
-        
+            #Format and print the output
+            Write-Host "Users who have access:`n"
+            Write-Host $AccessList 
     }
-    #Format and print the output
-    Write-Host "Users who have access:`n"
-    Write-Host $AccessList 
+    
 }


### PR DESCRIPTION
Moved print results to be in the condition so that there are no results printed when there is no mailbox found.